### PR TITLE
When Alpha|Beta release is done then create a"pre-release" Github release 

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -117,6 +117,7 @@ jobs:
           JRELEASER_TAG_NAME: ${{ inputs.release_version }}
           JRELEASER_PREVIOUS_TAG_NAME: ${{ inputs.previous_version }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          JRELEASER_PRERELEASE_PATTERN: .*(?:Alpha|alpha|Beta|beta)[0-9]
       - name: JReleaser - generate log
         if: always()
         working-directory: repository


### PR DESCRIPTION
- Change comming from:  https://jreleaser.org/guide/latest/configuration/release/github.html
- If released version is Alpha or Beta then we will create a `pre-release` gh release as shown in the image below
![Screenshot from 2022-09-01 16-01-54](https://user-images.githubusercontent.com/2582866/187933764-5cec12ad-9f0a-49cb-9c33-46b9d685efbe.png)

> NOTE: This doesn't prevent the CHANGELOG to be generated. The CHANGELOG is generated regarless of the type of release we are doing "Final", "Alpha", "Beta". We can not avoid creating the CHANGELOG so far since it is not a feature in JReleaser.
