### PR TITLE
Remove liveness and readiness probes from JSON Example (operator)

### DIFF
--- a/operator/template/manifests/windup-operator.clusterserviceversion.yaml
+++ b/operator/template/manifests/windup-operator.clusterserviceversion.yaml
@@ -83,8 +83,6 @@ metadata:
            "executor_mem_request": "0.5Gi",
            "executor_cpu_limit": "4",
            "executor_mem_limit": "4Gi",
-           "web_readiness_probe": "/bin/bash,-c,${JBOSS_HOME}/bin/jboss-cli.sh --connect --commands='/core-service=management:read-boot-errors()' | grep '\"result\" => \\[]' && ${JBOSS_HOME}/bin/jboss-cli.sh --connect --commands='ls deployment' | grep 'api.war'",
-           "web_liveness_probe": "/bin/bash,-c,${JBOSS_HOME}/bin/jboss-cli.sh --connect --commands='/core-service=management:read-boot-errors()' | grep '\"result\" => \\[]' && ${JBOSS_HOME}/bin/jboss-cli.sh --connect --commands=ls | grep 'server-state=running'",
            "executor_readiness_probe": "/bin/bash, -c, /opt/windup-cli/bin/livenessProbe.sh",
            "executor_liveness_probe": "/bin/bash, -c, /opt/windup-cli/bin/livenessProbe.sh",
            "executor_desired_replicas": 1,

--- a/operator/template/manifests/windup-operator.clusterserviceversion.yaml
+++ b/operator/template/manifests/windup-operator.clusterserviceversion.yaml
@@ -83,8 +83,6 @@ metadata:
            "executor_mem_request": "0.5Gi",
            "executor_cpu_limit": "4",
            "executor_mem_limit": "4Gi",
-           "executor_readiness_probe": "/bin/bash, -c, /opt/windup-cli/bin/livenessProbe.sh",
-           "executor_liveness_probe": "/bin/bash, -c, /opt/windup-cli/bin/livenessProbe.sh",
            "executor_desired_replicas": 1,
            "tls_secret": "",
            "ingress_custom_labels": ""


### PR DESCRIPTION
Remove readiness and liveness probes due to wrong formatting by operatorhub.io
The commands from the probes are deleted in the YAML Example.

https://github.com/k8s-operatorhub/community-operators/pull/1908
https://github.com/k8s-operatorhub/community-operators/pull/1909

Signed-off-by: carlosthe19916 <2582866+carlosthe19916@users.noreply.github.com>