### PR TITLE
quickstarts release: Add only xml files to git

### DIFF
--- a/scripts/repository.sh
+++ b/scripts/repository.sh
@@ -63,5 +63,5 @@ function setNextVersion_windupMavenPlugin() {
 function setNextVersion_windupQuickstarts() {
   MVN_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
   find . -name pom.xml -exec sed -i -e "s/${MVN_VERSION}/${NEXT_VERSION}/g" {} \;
-  git add -A
+  git add \*.xml
 }


### PR DESCRIPTION
Current script is adding all changed files to GIT when windu-quickstart is released.
This PR changes the script and it will only add XML files to the git changes