### PR TITLE
(fix): switch "Run After script" and  "Set next development version" order

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -151,19 +151,19 @@ jobs:
         with:
           name: ${{ inputs.repository }}-jreleaser-log
           path: "repository/jreleaser-log.tgz"
-      - name: Set next development version ${{ inputs.next_development_version }}
-        run: |
-          export SETTINGS_XML=$(readlink -f ci/maven/settings.xml)
-          source ci/scripts/utils.sh
-          cd repository && setNextDevelopmentVersion
-        env:
-          NEXT_VERSION: ${{ inputs.next_development_version }}
       - name: Run After script
         if: ${{ inputs.run_after }}
         run: |
           export SETTINGS_XML=$(readlink -f ci/maven/settings.xml)
           source ci/scripts/repository.sh
           cd repository && eval ${{ inputs.run_after }}
+        env:
+          NEXT_VERSION: ${{ inputs.next_development_version }}
+      - name: Set next development version ${{ inputs.next_development_version }}
+        run: |
+          export SETTINGS_XML=$(readlink -f ci/maven/settings.xml)
+          source ci/scripts/utils.sh
+          cd repository && setNextDevelopmentVersion
         env:
           NEXT_VERSION: ${{ inputs.next_development_version }}
       - name: Commit and Push


### PR DESCRIPTION
Signed-off-by: carlosthe19916 <2582866+carlosthe19916@users.noreply.github.com>

This PR will prevent the windup-quickstarts not to have the `windup.version` property changed.
This PR is associated with https://github.com/windup/windup-quickstarts/pull/107  where a manual change needed to be done to fix the non proper change of versions 