### PR TITLE
WINDUP-3763 Add CLI container multi-arch build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,25 +161,25 @@ jobs:
           key: ${{ runner.os }}-maven-windup-openshift-container-images-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-maven-windup-web-${{ github.run_id }}
-      - name: Create container images
-        run: |
-          mvn install -DskipTests \
-          -Ddocker.name.windup.web=quay.io/windupeng/windup-web-openshift:$TAG \
-          -Ddocker.name.windup.web.executor=quay.io/windupeng/windup-web-openshift-messaging-executor:$TAG \
-          -Ddocker.name.windup.cli=quay.io/windupeng/windup-cli-openshift:$TAG
-        env:
-          TAG: ${{ github.event.inputs.release_version }}
       - name: Login to Registry
         uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
+      - name: Create container images
+        run: |
+          mvn install -DskipTests \
+          -Ddocker.name.windup.web=quay.io/windupeng/windup-web-openshift:$TAG \
+          -Ddocker.name.windup.web.executor=quay.io/windupeng/windup-web-openshift-messaging-executor:$TAG \
+          -Ddocker.name.windup.cli=quay.io/windupeng/windup-cli-openshift:$TAG \
+          -Dmulti-arch -Djib.httpTimeout=0
+        env:
+          TAG: ${{ github.event.inputs.release_version }}
       - name: Push images to registry
         run: |
           docker image push --all-tags quay.io/windupeng/windup-web-openshift
           docker image push --all-tags quay.io/windupeng/windup-web-openshift-messaging-executor
-          docker image push --all-tags quay.io/windupeng/windup-cli-openshift
 
   windup-web-distribution:
     needs: [ windup-openshift ]

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -146,21 +146,21 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-      - name: Build container images
-        run: |
-          mvn deploy -DskipTests \
-          -Ddocker.name.windup.web.executor=quay.io/windupeng/windup-web-openshift-messaging-executor \
-          -Ddocker.name.windup.cli=quay.io/windupeng/windup-cli-openshift \
-          -Ddocker.name.windup.web=quay.io/windupeng/windup-web-openshift
       - name: Login to Registry
         uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
+      - name: Build container images
+        run: |
+          mvn deploy -DskipTests \
+          -Ddocker.name.windup.web.executor=quay.io/windupeng/windup-web-openshift-messaging-executor \
+          -Ddocker.name.windup.cli=quay.io/windupeng/windup-cli-openshift \
+          -Ddocker.name.windup.web=quay.io/windupeng/windup-web-openshift \
+          -Dmulti-arch -Djib.httpTimeout=0
       - name: Push images to Registry
         run: |
-          docker push quay.io/windupeng/windup-cli-openshift
           docker push quay.io/windupeng/windup-web-openshift-messaging-executor
           docker push quay.io/windupeng/windup-web-openshift
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3763

With https://github.com/windup/windup-openshift/pull/75 the Windup CLI container is built as a multi-arch container and it requires to be pushed during the build process so the login to podman has been moved before running the Maven build in order to have valid credentials when the build runs to let the CLI container image to be successfully pushed.
The options to build the multi-arch container has been added to the command and the `podman push` for the CLI container removed as it's useless.