### PR TITLE
Changed 'setNextVersion_windupMavenPlugin' to reflect changes in the repo

### DIFF
--- a/scripts/repository.sh
+++ b/scripts/repository.sh
@@ -49,15 +49,21 @@ function setNextVersion_windupMavenPlugin() {
   sed -i -e "s/<version>.*<\/version>/<version>${NEXT_VERSION}<\/version>/g" ${theme}/src/it/simple-it/pom.xml
   git add ${theme}/src/it/simple-it/pom.xml
   
-  sed -i -e "s/<version>.*<\/version>/<version>${NEXT_VERSION}<\/version>/g" ${theme}/src/test/resources/mojoTestConfig.xml
-  git add ${theme}/src/test/resources/mojoTestConfig.xml
-  
   sed -i -e "s/assertEquals(mojo2.getWindupVersion(), \".*\");/assertEquals(mojo2.getWindupVersion(), \"${NEXT_VERSION}\");/g" ${theme}/src/test/java/org/jboss/windup/plugin/WindupMojoTest.java
   git add ${theme}/src/test/java/org/jboss/windup/plugin/WindupMojoTest.java
   done
   
-  sed -i -e "s/<windupVersion>.*<\/windupVersion>/<windupVersion>${NEXT_VERSION}<\/windupVersion>/g" windup-plugin/src/test/resources/mojoTestConfigWithWindupVersion.xml
-  git add windup-plugin/src/test/resources/mojoTestConfigWithWindupVersion.xml
+  for theme in mta-plugin mtr-plugin
+  do
+  sed -i -e "s/<version>.*<\/version>/<version>${NEXT_VERSION}<\/version>/g" ${theme}/src/test/resources/mojoTestConfig.xml
+  git add ${theme}/src/test/resources/mojoTestConfig.xml
+  done
+  
+  sed -i -e "s/<version>.*<\/version>/<version>${NEXT_VERSION}<\/version>/g" windup-plugin/src/test/resources/mojoTestConfig/pom.xml
+  git add windup-plugin/src/test/resources/mojoTestConfig/pom.xml
+  
+  sed -i -e "s/<windupVersion>.*<\/windupVersion>/<windupVersion>${NEXT_VERSION}<\/windupVersion>/g" windup-plugin/src/test/resources/mojoTestConfigWithWindupVersion/pom.xml
+  git add windup-plugin/src/test/resources/mojoTestConfigWithWindupVersion/pom.xml
 }
 
 function setNextVersion_windupQuickstarts() {


### PR DESCRIPTION
fixes https://github.com/windup/windup-pipelines/actions/runs/4869521635/jobs/8685555359

`windup-plugin/src/test/resources/` folder is now different from other themed corresponding folders so it's management has been pulled out of the `for` loop