### PR TITLE
Workaround for cache failure

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -184,3 +184,8 @@ jobs:
           working-directory: repository
           branch: ${{ inputs.branch }}
           commit_message: "⬆️ Next version ${{ inputs.next_development_version }}"
+      - run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"


### PR DESCRIPTION
It's a workaround GH support suggested to avoid https://github.com/windup/windup-pipelines/actions/runs/5961136796/job/16207290086#step:35:3